### PR TITLE
Permitindo especificar grupos de comandos como arrays

### DIFF
--- a/bot/services/caixa2-service.js
+++ b/bot/services/caixa2-service.js
@@ -1,0 +1,23 @@
+const _ = require('lodash');
+
+const command = {
+  USER_ADD: 'add-user',
+  USER_LIST: 'list-user',
+};
+
+class Caixa2Service {
+  constructor (client) {
+    this.client = client;
+  }
+
+  /**
+   * 
+   * @param {Array<string>} splittedCommand Original command, split in spaces, e.g.
+   * @param {*} channel 
+   */
+  process (splittedCommand, channel) {
+    if(splittedCommand.length)
+  }
+}
+
+module.exports = Caixa2Service;

--- a/bot/services/command-service.js
+++ b/bot/services/command-service.js
@@ -21,12 +21,12 @@ class CommandService {
     let splittedCommand = command.split(' ');
     
     // Match group-less first
-    if(matches(splittedCommand, withoutGroup.PING)) {
+    if(matches(splittedCommand[0], withoutGroup.PING)) {
       channel.send('Rá toma no cu!');
     }
     
     // Match grouped commands
-    if(matches(splittedCommand, groups.LOUNGE)) {
+    if(matches(splittedCommand[0], groups.LOUNGE)) {
       this.loungeGroup(splittedCommand, channel);
     }
   }

--- a/bot/services/command-service.js
+++ b/bot/services/command-service.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 
 const withoutGroup = {
   PING: 'ping'
@@ -7,7 +8,7 @@ const groups = {
 };
 const loungeGroup = {
   USER_ADD: 'add-user',
-  USER_LIST: 'list-user'
+  USER_LIST: 'list-user',
 };
 
 class CommandService {
@@ -18,14 +19,31 @@ class CommandService {
 
   execute (command, { channel }) {
     let splittedCommand = command.split(' ');
-    switch (splittedCommand[0]) {
-      case groups.LOUNGE:
-        this.loungeGroup(splittedCommand, channel);
-        break;
-      case withoutGroup.PING:
-        channel.send('Rá toma no cu!');
-        break;
+    
+    // Match group-less first
+    if(matches(splittedCommand, withoutGroup.PING)) {
+      channel.send('Rá toma no cu!');
     }
+    
+    // Match grouped commands
+    if(matches(splittedCommand, groups.LOUNGE)) {
+      this.loungeGroup(splittedCommand, channel);
+    }
+  }
+
+  matches (command, group) {
+    
+    if (_.isString(group)) {
+      return group == command;
+    }
+    // Match any in array
+    if (_.isArray(group)) {
+      return group.indexOf(command) != -1;
+    }
+
+    console.log('Expected group to be either string or array, received ' + typeof(group) + ' instead.');
+
+    return false;
   }
 
   loungeGroup (splittedCommand, channel) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "ffmpeg-binaries": "^3.2.2-3",
     "isomorphic-fetch": "^2.2.1",
+    "lodash": "^4.17.4",
     "multer": "^1.3.0",
     "opusscript": "0.0.3",
     "pm2": "^2.6.1",


### PR DESCRIPTION
Serve pra criar aliases do mesmo grupo, ex: `/ubot ban renan` e `/ubot b renan` mapeariam para o mesmo comando.

Vou usar isso depois pra poder criar o comando de registrar dívidas Caixa 2™ como `/ubot caixa2 ...` e `/ubot $ ...`.